### PR TITLE
Set background image through options page

### DIFF
--- a/content.js
+++ b/content.js
@@ -5,25 +5,26 @@ function setTarget(coll) {
   })
 }
 setTimeout(function() {
-  var swimlaneLinks = $('.ghx-swimlane').find('a')
+  var swimlaneLinks = $('.ghx-swimlane').find('a');
   $.each(swimlaneLinks, function() {
-    var location = $(this).attr('href')
-    var newTabLink = $(document.createElement('a')).text('(Open in tab)').attr('href', location).attr('style', 'margin-left: 1rem; font-size: 0.8rem;')
-    $($(this).parent()).append(newTabLink)
+    var location = $(this).attr('href');
+    var newTabLink = $(document.createElement('a')).text('(Open in tab)').attr('href', location).attr('style', 'margin-left: 1rem; font-size: 0.8rem;');
+    $($(this).parent()).append(newTabLink);
     $(newTabLink).on('click', function() {
-      window.open(location, '_blank')
-    })
-  })
+      window.open(location, '_blank');
+    });
+  });
 
   // Description Links
-  setTarget($('#description-val').find('a'))
+  setTarget($('#description-val').find('a'));
   // Comment Links
-  setTarget($('.action-body').find('a'))
+  setTarget($('.action-body').find('a'));
 
   // Clear background on swimlane columns
-  $('.ghx-column').attr('style', 'background-color:rgba(0, 0, 0, 0)')
-  $('.ghx-columns').attr('style', 'background:url(' + chrome.extension.getURL('images/basket-full-of-kittens.jpg') + ');')
-}, 1500)
-
-
-
+  $('.ghx-column').attr('style', 'background-color:rgba(0, 0, 0, 0)');
+  chrome.storage.sync.get({
+    background: chrome.extension.getURL('images/basket-full-of-kittens.jpg')
+  }, function(items) {
+    $('.ghx-columns').attr('style', 'background:url(' + items.background + ');');
+  });
+}, 1500);

--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,9 @@
   ],
   "web_accessible_resources": [
     "images/basket-full-of-kittens.jpg"
-  ]
+  ],
+  "permissions": [
+    "storage"
+  ],
+  "options_page": "options.html"
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>GAJira Options</title>
+    <style>
+      body {
+        padding: 24px;
+        max-width: 800px;
+        margin: 0 auto;
+        font-size: 16px;
+      }
+      input {
+        font-size: 16px;
+        margin-top: 6px;
+        margin-bottom: 6px;
+        padding: 12px;
+        width: 480px;
+        max-width: 100%;
+      }
+      button {
+        font-size: 16px;
+        padding: 12px;
+      }
+      .option-group {
+        margin-top: 12px;
+        margin-bottom: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>GAJira Options</h1>
+
+    <div class="option-group">
+      <label>
+        Background image (enter URL to image)
+        <br>
+        <input id="background" type="text">
+      </label>
+    </div>
+
+    <div class="option-group">
+      <button id="save">Save Preferences</button>
+      <button id="default">Revert to Default</button>
+    </div>
+
+    <div id="status"></div>
+
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,37 @@
+function saveOptions() {
+  var background = document.getElementById('background').value;
+  chrome.storage.sync.set({
+    background: background
+  }, function() {
+    displayStatus('Options saved');
+  });
+}
+
+function defaultOptions() {
+  var background = document.getElementById('background').value;
+  chrome.storage.sync.set({
+    background: chrome.extension.getURL('images/basket-full-of-kittens.jpg')
+  }, function() {
+    restoreOptions();
+    displayStatus('Reverted to defaults');
+  });
+}
+
+function displayStatus(message) {
+  var status = document.getElementById('status');
+  status.textContent = message;
+  setTimeout(function() {
+    status.textContent = '';
+  }, 1500);
+}
+
+function restoreOptions() {
+  chrome.storage.sync.get({
+    background: chrome.extension.getURL('images/basket-full-of-kittens.jpg')
+  }, function(items) {
+    document.getElementById('background').value = items.background;
+  });
+}
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('save').addEventListener('click', saveOptions);
+document.getElementById('default').addEventListener('click', defaultOptions);


### PR DESCRIPTION
### Description
- Added an options page, allows user to set custom background image (kitten image used as default)
- Added some semicolons to existing JS
### How To

You can access the options page either from your extensions:

<img width="805" alt="screen shot 2016-04-21 at 1 07 04 am" src="https://cloud.githubusercontent.com/assets/4241399/14698493/7244d23e-075d-11e6-9371-fe7b653ef462.png">

or through the plugin's menu in your Chrome toolbar (top-right)

<img width="426" alt="screen shot 2016-04-21 at 1 08 09 am" src="https://cloud.githubusercontent.com/assets/4241399/14698508/976a203c-075d-11e6-9d84-ca486dd7a7ad.png">
### Screenshots

**Options page**

<img width="618" alt="screen shot 2016-04-21 at 1 04 25 am" src="https://cloud.githubusercontent.com/assets/4241399/14698466/13685e34-075d-11e6-9cc2-cb17cae3a68e.png">

**JIRA with a custom background image**

<img width="1249" alt="screen shot 2016-04-21 at 1 05 08 am" src="https://cloud.githubusercontent.com/assets/4241399/14698469/1bca945c-075d-11e6-97ee-3124c666bda0.png">
